### PR TITLE
de: fix Menü truncation and missing space in promo/timer strings

### DIFF
--- a/death/index.js
+++ b/death/index.js
@@ -39,7 +39,7 @@ export default {
         ru: 'При выборе этого пункта будет запущен таймер в {{time}} минут, после чего вы попадете в ближайшую больницу',
         ua: 'При виборі цього пункту буде запущений таймер на {{time}} хвилин, після чого ви потрапите до найближчої лікарні',
         en: 'Choosing this option will start a {{time}} minute timer, after which you will be taken to the nearest hospital',
-        de: 'Wenn du diese Option wählst, startet ein {{time}}-Minuten-Timer.Nach Ablauf wirst du automatisch ins nächste Krankenhaus gebracht',
+        de: 'Wenn du diese Option wählst, startet ein {{time}}-Minuten-Timer. Nach Ablauf wirst du automatisch ins nächste Krankenhaus gebracht',
         pl: 'Wybranie tej opcji uruchomi licznik {{time}} minutowy, po którym zostaniesz przetransportowany do najbliższego szpitala',
         zh:'如果你选择了这个，你将在15分钟后被送进最近的医院',
     },

--- a/donate/server.js
+++ b/donate/server.js
@@ -3,7 +3,7 @@ export const server = {
         ua: 'Створено випадковий промокод ~o~{{promo}} ~w~на ~o~{{sum}} донат валюти ~w~ <br>Він буде діяти рівно ~o~5 хвилин ~w~, встигни ввести його в <br>~g~Меню > Магазин > Промокод',
         en: 'Created a random promo code ~o~{{promo}} ~w~for ~o~{{sum}} donation currency ~w~ <br>It will work for exactly ~o~5 minutes ~w~, hurry up to enter it in <br>~g~Menu > Store > Promo Code',
         ru: 'Создан случайный промокод ~o~{{promo}} ~w~на ~o~{{sum}} донат валюты ~w~ <br>Он будет работать ровно ~o~5 минут ~w~, успей ввести его в <br>~g~Меню > Магазин > Промокод',
-        de: 'Ein zufälliger Promo-Code wurde erstellt: ~o~{{promo}} ~w~dieser gibt dir ~o~{{sum}} OlympCoins. ~w~ <br>Er ist genau ~o~5 Minuten ~w~ gültig, beeil dich und gib ihn über <br>~g~M > Shop > Promo-Code ein.',
+        de: 'Ein zufälliger Promo-Code wurde erstellt: ~o~{{promo}} ~w~dieser gibt dir ~o~{{sum}} OlympCoins. ~w~ <br>Er ist genau ~o~5 Minuten ~w~ gültig, beeil dich und gib ihn über <br>~g~Menü > Shop > Promo-Code ein.',
         pl: 'Utworzono losowy kod promocyjny ~o~{{promo}} ~w~dla ~o~{{sum}} waluty donacyjnej ~w~ <br>Będzie działać przez dokładnie ~o~5 minut ~w~, śpiesz się, aby go wprowadzić w <br>~g~Menu > Sklep > Kod promocyjny',
         zh: '随机代码~o~{promo}}~w~关于~o~{sum}}货币捐赠~w~<br>它将同样有效~o~5分钟~w~，请在<br>~g~菜单>杂志>代码中输入它',
     },


### PR DESCRIPTION
Follow-up fixes after merging #46 and #56.

## Summary
- `donate/server.js`: restore `Menü >` (was truncated to `M >` in #56). Matches sibling file `donate/cases.js:552` which uses `Menü > Shop > Inventar`.
- `death/index.js`: add missing space in `{{time}}-Minuten-Timer.Nach Ablauf` -> `{{time}}-Minuten-Timer. Nach Ablauf` (regression from #46).

## Test plan
- [ ] Visual check of the two messages in-game (promo code created, death menu)